### PR TITLE
Fix: Only intercept AJAX requests

### DIFF
--- a/src/js/core/RequestListener.js
+++ b/src/js/core/RequestListener.js
@@ -14,6 +14,11 @@ export default class RequestListener extends EventEmitter {
   onBeforeRequest(request) {
     let url = request.url;
 
+    // Discard everything except AJAX HTTP requests.
+    if (request.type !== 'xmlhttprequest') {
+      return;
+    }
+
     // Skip any chrome requests... I.e. chrome:// or chrome-extension://...
     if (url.indexOf('chrome') === 0) {
       return;


### PR DESCRIPTION
Adds a filter to the request listener so that only AJAX requests are handled.
#### How to verify

Add a `console.log(request);` on line 21 in `src/js/core/RequestListener.js`. Visit several pages and verify that only AJAX requests are written to console. Images etc should not be.

Fixes #8 
