### PR TITLE
Migrate from array destructuring

### DIFF
--- a/assets/js/console-jwt.js
+++ b/assets/js/console-jwt.js
@@ -16,7 +16,10 @@
       return false;
     }
 
-    var [header, body, signature] = value.split('.');
+    var tokens = value.split('.');
+    var header = tokens[0];
+    var body = tokens[1];
+    var signature = tokens[2];
 
     try {
       return new JWT(


### PR DESCRIPTION
The code breaks on chromium 48 and any old Chrome versions that do not support es6.

https://www.chromestatus.com/feature/4588790303686656
